### PR TITLE
added support for custom wrapper circle

### DIFF
--- a/MRCircularProgressView/MRCircularProgressView/MRCircularProgressView.h
+++ b/MRCircularProgressView/MRCircularProgressView/MRCircularProgressView.h
@@ -30,13 +30,19 @@
 @interface MRCircularProgressView : UIView
 
 // Set delegate to allow callbacks (animataionDidFinish, etc)
-@property(strong, nonatomic) id delegate;
+@property (strong, nonatomic) id delegate;
 
-// Color of wrapper circle and progress arc.
-@property(strong, nonatomic) UIColor *progressColor;
+// Color of the progress arc
+@property (strong, nonatomic) UIColor *progressColor;
 
 // Width of progress arc
 @property (assign, nonatomic) CGFloat progressArcWidth;
+
+// Width of wrapper arc
+@property (assign, nonatomic) CGFloat wrapperArcWidth;
+
+// Color of wrapper arc
+@property (strong, nonatomic) UIColor *wrapperColor;
 
 // Set new progress (0.0f - 1.0f) with animation option
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animate;

--- a/MRCircularProgressView/MRCircularProgressView/MRCircularProgressView.m
+++ b/MRCircularProgressView/MRCircularProgressView/MRCircularProgressView.m
@@ -60,15 +60,17 @@
     self.lastProgress = 0.0f;
     self.animated = YES;
     self.progressColor = [UIColor blueColor];
+    self.wrapperColor = self.progressColor;
     self.duration = 0.5;
     self.progressArcWidth = 3.0f;
+    self.wrapperArcWidth = 1.f;
 }
 
 - (void)drawRect:(CGRect)rect
 {
     // Outer circle
     CGRect newRect = ({
-        CGRect insetRect = CGRectInset(rect, 1.5f, 1.5f);
+        CGRect insetRect = CGRectInset(rect, self.wrapperArcWidth + 0.5f, self.wrapperArcWidth + 0.5f);
         CGRect newRect = insetRect;
         newRect.size.width = MIN(CGRectGetMaxX(insetRect), CGRectGetMaxY(insetRect));
         newRect.size.height = newRect.size.width;
@@ -77,8 +79,8 @@
         newRect;
     });
     UIBezierPath *outerCircle = [UIBezierPath bezierPathWithOvalInRect:newRect];
-    [self.progressColor setStroke];
-    outerCircle.lineWidth = 1;
+    [self.wrapperColor setStroke];
+    outerCircle.lineWidth = self.wrapperArcWidth;
     [outerCircle stroke];
 }
 


### PR DESCRIPTION
This let's users customize the appearance of the back wrapper circle. Especially handy when you want the wrapper to be the same size as the progress circle.
